### PR TITLE
Feat: auto journal links

### DIFF
--- a/lua/field_notes/augroups.lua
+++ b/lua/field_notes/augroups.lua
@@ -1,0 +1,42 @@
+local M = {}
+
+local augroup = vim.api.nvim_create_augroup
+local autocmd = vim.api.nvim_create_autocmd
+
+local opts = require("field_notes.opts")
+local utils = require("field_notes.utils")
+
+local function set_journal_link_augroup()
+    local group = augroup("field_notes_link_journal", {clear = true})
+    autocmd(
+        {"BufWrite"},
+        {
+            group = group,
+            pattern = "*." .. opts.get().file_extension,
+            callback = function()
+                if utils.buffer_is_in_field_notes(0, "notes") then
+                    for k, v in pairs(opts.get().auto_add_links_to_journal) do
+                        if v then
+                            utils.add_field_note_link_at_current_journal(
+                                utils.slugify(vim.fn.expand("%:t:r")), k
+                            )
+                        end
+                    end
+
+                end
+            end,
+        }
+    )
+
+end
+
+function M.set()
+    for _, v in pairs(opts.get().auto_add_links_to_journal) do
+        if v then
+            set_journal_link_augroup()
+            break
+        end
+    end
+end
+
+return M

--- a/lua/field_notes/core/journal.lua
+++ b/lua/field_notes/core/journal.lua
@@ -20,17 +20,8 @@ function M.cur_buf_journal_timescale()
 end
 
 local function edit_journal(timescale, timestamp)
-    timestamp = timestamp or os.time()
-
-    local date_title_fmt = opts.get().journal_date_title_formats[timescale]
-    local title = os.date(date_title_fmt, timestamp)
-
-    local timescale_dir = opts.get().journal_subdirs[timescale]
-    local file_dir = table.concat({
-        opts.get().field_notes_path,
-        opts.get().journal_dir,
-        timescale_dir,
-    }, '/')
+    local title = utils.get_journal_title(timescale, timestamp)
+    local file_dir = utils.get_journal_dir(timescale)
     utils.create_dir(file_dir)
     utils.edit_note(file_dir, title)
 end

--- a/lua/field_notes/init.lua
+++ b/lua/field_notes/init.lua
@@ -2,10 +2,12 @@ local M = {}
 
 local opts = require("field_notes.opts")
 local commands = require("field_notes.commands")
+local augroups = require("field_notes.augroups")
 
 function M.setup(config)
     opts.set(config or {})
     commands.set()
+    augroups.set()
 end
 
 return M

--- a/lua/field_notes/opts.lua
+++ b/lua/field_notes/opts.lua
@@ -21,7 +21,11 @@ local default_opts = {
         up = nil,
         right = nil,
     },
-    auto_add_links_to_journal = true,
+    auto_add_links_to_journal = {
+        day = true,
+        week = false,
+        month = false,
+    },
     journal_link_anchor = "## Field notes",
     _vert = true,
 }

--- a/lua/field_notes/opts.lua
+++ b/lua/field_notes/opts.lua
@@ -22,7 +22,7 @@ local default_opts = {
         right = nil,
     },
     auto_add_links_to_journal = {
-        day = true,
+        day = false,
         week = false,
         month = false,
     },

--- a/lua/field_notes/opts.lua
+++ b/lua/field_notes/opts.lua
@@ -21,6 +21,8 @@ local default_opts = {
         up = nil,
         right = nil,
     },
+    auto_add_links_to_journal = true,
+    journal_link_anchor = "## Field notes",
     _vert = true,
 }
 

--- a/lua/field_notes/utils.lua
+++ b/lua/field_notes/utils.lua
@@ -54,6 +54,37 @@ function M.edit_note(file_dir, title)
     end
 end
 
+function M.get_journal_title(timescale, timestamp)
+    timestamp = timestamp or os.time()
+    local opts = require("field_notes.opts")
+    local date_title_fmt = opts.get().journal_date_title_formats[timescale]
+    return os.date(date_title_fmt, timestamp)
+end
+
+function M.get_journal_dir(timescale)
+    local opts = require("field_notes.opts")
+    if not timescale then
+        return table.concat({
+            opts.get().field_notes_path,
+            opts.get().journal_dir,
+        }, '/')
+    end
+    local timescale_dir = opts.get().journal_subdirs[timescale]
+    return table.concat({
+        opts.get().field_notes_path,
+        opts.get().journal_dir,
+        timescale_dir,
+    }, '/')
+end
+
+function M.get_notes_dir()
+    local opts = require("field_notes.opts")
+    return table.concat({
+        opts.get().field_notes_path,
+        opts.get().notes_dir,
+    }, '/')
+end
+
 function M.add_field_note_link_at_cursor(filename)
     local link_string = table.concat({"[[", filename, "]]"})
     local cursor = vim.api.nvim_win_get_cursor(0)

--- a/lua/field_notes/utils.lua
+++ b/lua/field_notes/utils.lua
@@ -95,11 +95,23 @@ function M.add_field_note_link_at_cursor(filename)
 end
 
 function M.buffer_is_in_field_notes(buf_idx)
+function M.buffer_is_in_field_notes(buf_idx, subdir)
     buf_idx = buf_idx or 0
     local opts = require("field_notes.opts")
 
     local buf_path = vim.api.nvim_buf_get_name(buf_idx)
+
     local field_notes_path = vim.fn.expand(opts.get().field_notes_path)
+    if subdir then
+        if subdir == "notes" then
+            field_notes_path = M.get_notes_dir()
+        elseif subdir == "journal" then
+            field_notes_path = M.get_journal_dir()
+        elseif M.is_timescale(subdir) then
+            field_notes_path = M.get_journal_dir(subdir)
+        end
+    end
+
     if field_notes_path:sub(-1) ~= "/" then field_notes_path = field_notes_path .. '/' end
 
     local field_notes_path_in_buf_path = string.find(buf_path, field_notes_path, 1, true)


### PR DESCRIPTION
This change implements auto link creation within the current journal page when creating a note with the `:FieldNote` command and saving it. 

This will open the specified journal page in an unlisted buffer, search for a line starting with a "notes anchor" (such as `## Field Notes`, configurable), add the link to a list underneath the anchor (`* [[slugified_note_name]]`) then write and unload the journal buffer.

This is configurable through the setup 
```lua
require("field_notes").setup(
    {
        ...
        auto_add_links_to_journal = {
            day = true,
            week = false,
            month = false,
        },
        journal_link_anchor = "## Field notes",
    }
)

```